### PR TITLE
Shave allocs using new reflect api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ profile: clean
 	go test -run=xxx -bench=BenchmarkImmcheckTransactions ./... -cpuprofile profile.out
 	go tool pprof -http=:8080 profile.out
 
+profile_mem: clean
+	go test -run=xxx -bench=BenchmarkImmcheckTransactions ./... -memprofile profile.out
+	go tool pprof -http=:8080 profile.out
+
 debug_inline:
 	go build -gcflags='-m -d=ssa/check_bce/debug=1' ./immcheck.go
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/goodbadreviewer/immcheck
 
 go 1.18
 
-require github.com/zeebo/xxh3 v1.0.2
+require (
+	github.com/storozhukBM/pcache v1.0.1
+	github.com/zeebo/xxh3 v1.0.2
+)
 
 require github.com/klauspost/cpuid/v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/storozhukBM/pcache v1.0.1 h1:1Qyfyk964tCnTpI1Mcpks0WrflTH/mc1TJw0qyOZNP4=
+github.com/storozhukBM/pcache v1.0.1/go.mod h1:JY0pGdDJSJ3FkDSTzpWKqqEnTbDxVGo8qytyDqUIhJw=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/immcheck.go
+++ b/immcheck.go
@@ -331,12 +331,10 @@ func captureChecksumMap(snapshot *ValueSnapshot, value reflect.Value, options Op
 	return snapshot
 }
 
-//go:nosplit
 func evalKey32(valuePointer uint32, kind reflect.Kind) uint32 {
 	return valuePointer ^ uint32(kind)
 }
 
-//go:nosplit
 func evalKey(valuePointer uintptr, kind reflect.Kind) uint32 {
 	return uint32(valuePointer) ^ uint32(kind)
 }
@@ -405,13 +403,11 @@ func perItemSnapshot(snapshot *ValueSnapshot, value reflect.Value, options Optio
 	return snapshot
 }
 
-//go:nosplit
 func capturePointer(snapshot *ValueSnapshot, valuePointer unsafe.Pointer, valueKind reflect.Kind) *ValueSnapshot {
 	snapshot.checksums[evalKey(uintptr(valuePointer), valueKind)] = uint32(uintptr(valuePointer))
 	return snapshot
 }
 
-//go:nosplit
 func captureRawBytesLevelChecksum(
 	snapshot *ValueSnapshot,
 	valueBytes []byte, valueKind reflect.Kind,
@@ -421,7 +417,6 @@ func captureRawBytesLevelChecksum(
 	return snapshot
 }
 
-//go:nosplit
 func convertValueTypeToBytesSlice(value reflect.Value) []byte {
 	var result []byte
 	targetByteSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&result))
@@ -435,7 +430,6 @@ func convertValueTypeToBytesSlice(value reflect.Value) []byte {
 	return result
 }
 
-//go:nosplit
 func convertSliceBasedTypeToByteSlice(value reflect.Value) []byte {
 	var result []byte
 	targetByteSliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&result))
@@ -453,7 +447,6 @@ func convertSliceBasedTypeToByteSlice(value reflect.Value) []byte {
 	return result
 }
 
-//go:nosplit
 func pointerOfValue(value reflect.Value) unsafe.Pointer {
 	//nolint:exhaustive
 	switch value.Kind() {
@@ -471,7 +464,6 @@ func pointerOfValue(value reflect.Value) unsafe.Pointer {
 	panic(fmt.Sprintf("can't get pointer to value. kind: %#v; value: %#v", value.Kind().String(), value))
 }
 
-//go:nosplit
 func fetchDataPointerFromString(value reflect.Value) unsafe.Pointer {
 	stringValue := value.String()
 	return unsafe.Pointer(((*reflect.StringHeader)(unsafe.Pointer(&stringValue))).Data)
@@ -508,7 +500,6 @@ func checksumEquals(newChecksum map[uint32]uint32, originalChecksum map[uint32]u
 //nolint:gochecknoglobals // taskQueue is global to maximise goroutine pool utilization
 var taskQueue = make(chan func())
 
-//go:nosplit
 func runInPool(task func()) {
 	select {
 	case taskQueue <- task:

--- a/immcheck.go
+++ b/immcheck.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/storozhukBM/pcache"
 	"github.com/zeebo/xxh3"
 )
 
@@ -36,6 +37,9 @@ const (
 	// SkipLoggingOnMutation forces immcheck to not log details of found mutation
 	// in immcheck.EnsureImmutability and immcheck.CheckImmutabilityOnFinalization methods.
 	SkipLoggingOnMutation
+	// doNotDetectRefLoop can be used only internally to skip one cycle of detection and allow reuse of memory values
+	// in map entries capture look at immcheck.perEntrySnapshot.
+	doNotDetectRefLoop
 )
 
 // Options configures immutability check.
@@ -242,8 +246,8 @@ func reportError(v interface{}, checkErr error, options Options) {
 		}
 		_, _ = fmt.Fprintf(
 			logDestination,
-			"[ERROR] runtime mutation detected. value: `%#v`; error: %v\n",
-			v, checkErr,
+			"[ERROR] runtime mutation detected; error: %v\n",
+			checkErr,
 		)
 	}
 	if options.Flags&SkipPanicOnDetectedMutation == 0 {
@@ -252,7 +256,7 @@ func reportError(v interface{}, checkErr error, options Options) {
 }
 
 func newValueSnapshot() *ValueSnapshot {
-	oneBucketCapacity := 8
+	oneBucketCapacity := 16
 	return &ValueSnapshot{
 		captureOriginFile: &bytes.Buffer{},
 		captureOriginLine: 0,
@@ -295,10 +299,13 @@ func captureChecksumMap(snapshot *ValueSnapshot, value reflect.Value, options Op
 			return capturePointer(snapshot, valuePointer, valueKind)
 		}
 		// detect ref loop and skip
-		if _, ok := snapshot.checksums[evalKey(uintptr(valuePointer), valueKind)]; ok {
-			return snapshot
+		if options.Flags&doNotDetectRefLoop == 0 {
+			if _, loopDetected := snapshot.checksums[evalKey(uintptr(valuePointer), valueKind)]; loopDetected {
+				return snapshot
+			}
+			snapshot = capturePointer(snapshot, valuePointer, valueKind)
 		}
-		snapshot = capturePointer(snapshot, valuePointer, valueKind)
+		options.Flags &= ^doNotDetectRefLoop
 		snapshot = captureChecksumMap(snapshot, value.Elem(), options)
 		return snapshot
 	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
@@ -321,6 +328,12 @@ func captureChecksumMap(snapshot *ValueSnapshot, value reflect.Value, options Op
 		valuePointer := pointerOfValue(value)
 		if value.IsNil() || value.IsZero() {
 			return capturePointer(snapshot, valuePointer, valueKind)
+		}
+		// detect ref loop and skip
+		if options.Flags&doNotDetectRefLoop == 0 {
+			if _, loopDetected := snapshot.checksums[evalKey(uintptr(valuePointer), valueKind)]; loopDetected {
+				return snapshot
+			}
 		}
 		snapshot.checksums[evalKey(uintptr(valuePointer), valueKind)] = uint32(value.Len())
 		snapshot = perEntrySnapshot(snapshot, value, options)
@@ -361,20 +374,63 @@ func valueIsPrimitive(v reflect.Value) bool {
 	return false
 }
 
-var mapiterPool = &sync.Pool{New: func() interface{} { return &reflect.MapIter{} }}
+//nolint:gochecknoglobals // mapIterPool is global to maximise map iterators objects re-use
+var mapIterPool = &sync.Pool{New: func() interface{} { return &reflect.MapIter{} }}
+
+const maxPoolCacheSizePerGoroutine = 1024
+
+//nolint:gochecknoglobals // reflectValuePoolCache is global to maximise pools re-use
+var reflectValuePoolCache = pcache.NewPCache(maxPoolCacheSizePerGoroutine)
 
 func perEntrySnapshot(snapshot *ValueSnapshot, value reflect.Value, options Options) *ValueSnapshot {
-	iterator := mapiterPool.Get().(*reflect.MapIter)
+	iterator := mapIterPool.Get().(*reflect.MapIter)
 	defer func() {
 		iterator.Reset(reflect.Value{})
-		mapiterPool.Put(iterator)
+		mapIterPool.Put(iterator)
 	}()
 	iterator.Reset(value)
+
+	mapType := value.Type()
+	mapKeyType := mapType.Key()
+	mapValueType := mapType.Elem()
+
+	keyProvider, ok := reflectValuePoolCache.Load(mapKeyType.Name())
+	if !ok {
+		keyProvider = &sync.Pool{
+			New: func() interface{} {
+				poolValue := reflect.New(mapKeyType).Elem()
+				return &poolValue
+			},
+		}
+	}
+	defer reflectValuePoolCache.Store(mapKeyType.Name(), keyProvider)
+	keyPool := keyProvider.(*sync.Pool)
+	k := keyPool.Get().(*reflect.Value)
+	defer keyPool.Put(k)
+
+	valueProvider, ok := reflectValuePoolCache.Load(mapValueType.Name())
+	if !ok {
+		valueProvider = &sync.Pool{
+			New: func() interface{} {
+				poolValue := reflect.New(mapValueType).Elem()
+				return &poolValue
+			},
+		}
+	}
+	defer reflectValuePoolCache.Store(mapValueType.Name(), valueProvider)
+	valuePool := valueProvider.(*sync.Pool)
+	v := valuePool.Get().(*reflect.Value)
+	defer valuePool.Put(v)
+
 	for iterator.Next() {
-		k := iterator.Key()
-		v := iterator.Value()
-		snapshot = captureChecksumMap(snapshot, k, options)
-		snapshot = captureChecksumMap(snapshot, v, options)
+		k.SetIterKey(iterator)
+		v.SetIterValue(iterator)
+		snapshot = captureChecksumMap(snapshot, *k, options) // map cannot be a key in map
+		snapshot = captureChecksumMap(
+			snapshot, *v,
+			// map can reference itself in value, so we set doNotDetectRefLoop
+			Options{LogWriter: options.LogWriter, Flags: options.Flags | doNotDetectRefLoop},
+		)
 	}
 	return snapshot
 }


### PR DESCRIPTION
This change significantly reduces allocations but slows down checks of big byte slice:

```
name                                          old time/op    new time/op    delta
ImmcheckBytes/[16384]byte;muts(0%)-8            2.40µs ± 0%    2.51µs ± 2%   +4.66%  (p=0.000 n=8+8)
ImmcheckBytes/[16384]byte;muts(1%)-8            2.41µs ± 0%    2.51µs ± 0%   +4.24%  (p=0.000 n=10+10)
ImmcheckTransactions/[8]txs(8);muts(0%)-8       84.8µs ± 0%    83.2µs ± 0%   -1.95%  (p=0.000 n=9+10)
ImmcheckTransactions/[8]txs(8);muts(1%)-8       84.8µs ± 0%    83.3µs ± 0%   -1.70%  (p=0.000 n=10+8)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8    5.74ms ± 1%    5.77ms ± 1%     ~     (p=0.165 n=10+10)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8    5.73ms ± 2%    5.77ms ± 1%     ~     (p=0.065 n=10+9)

name                                          old alloc/op   new alloc/op   delta
ImmcheckBytes/[16384]byte;muts(0%)-8             0.00B          0.00B          ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8             0.00B          0.00B          ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(0%)-8       3.11kB ± 0%    0.56kB ± 1%  -81.99%  (p=0.000 n=10+10)
ImmcheckTransactions/[8]txs(8);muts(1%)-8       3.11kB ± 0%    0.56kB ± 1%  -81.82%  (p=0.000 n=10+10)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8    8.79kB ± 1%    5.74kB ± 1%  -34.65%  (p=0.000 n=9+10)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8    8.78kB ± 1%    5.77kB ± 1%  -34.28%  (p=0.000 n=10+10)

name                                          old allocs/op  new allocs/op  delta
ImmcheckBytes/[16384]byte;muts(0%)-8              0.00           0.00          ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8              0.00           0.00          ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         80.0 ± 0%       3.0 ± 0%  -96.25%  (p=0.000 n=10+10)
ImmcheckTransactions/[8]txs(8);muts(1%)-8         80.0 ± 0%       3.0 ± 0%  -96.25%  (p=0.000 n=10+10)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8       100 ± 0%        20 ± 0%  -80.00%  (p=0.002 n=7+8)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8       100 ± 0%        20 ± 0%  -80.00%  (p=0.002 n=8+10)
```