### PR TITLE
Use local pcache with full type name as key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/goodbadreviewer/immcheck
 
 go 1.18
 
-require (
-	github.com/storozhukBM/pcache v1.0.1
-	github.com/zeebo/xxh3 v1.0.2
-)
+require github.com/zeebo/xxh3 v1.0.2
 
 require github.com/klauspost/cpuid/v2 v2.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/storozhukBM/pcache v1.0.1 h1:1Qyfyk964tCnTpI1Mcpks0WrflTH/mc1TJw0qyOZNP4=
-github.com/storozhukBM/pcache v1.0.1/go.mod h1:JY0pGdDJSJ3FkDSTzpWKqqEnTbDxVGo8qytyDqUIhJw=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/pcache.go
+++ b/pcache.go
@@ -1,0 +1,76 @@
+package immcheck
+
+import (
+	"sync"
+)
+
+type typeName struct {
+	path string
+	name string
+}
+
+type cache map[typeName]interface{}
+
+type cacheStripe struct {
+	cache cache
+}
+
+// PCache is safe for concurrent use cache that tries to keep data local for the goroutine
+// and reduce synchronization overhead.
+//
+// Due to its implementation specifics,
+// in some edge cases, PCache can potentially restore previously-stored items after eviction,
+// so please take into account that it is possible and valid to observe "old" values of the specific key.
+// While this behavior is unconventional, it is totally usable for immutable key-value pairs,
+// keys that will always resolve into the same value,
+// and just in cases when it is easy for you to identify that the value is old and drop it or set to the new one.
+//
+// All operations run in amortized constant time.
+// PCache does its best to cache items inside and do as little synchronization as possible
+// but since it is cache, there is no guarantee that PCache won't evict your item after Store.
+//
+// PCache evicts random items if I goroutine local cache achieves maxSizePerGoroutine size.
+// PCache cleans itself entirely from time to time.
+//
+// The zero PCache is invalid. Use NewPCache method to create PCache.
+type PCache struct {
+	maxSize int
+	pool    *sync.Pool
+}
+
+// NewPCache creates PCache with maxSizePerGoroutine.
+func NewPCache(maxSizePerGoroutine uint) *PCache {
+	return &PCache{
+		maxSize: int(maxSizePerGoroutine),
+		pool: &sync.Pool{
+			New: func() interface{} {
+				return &cacheStripe{
+					cache: make(cache),
+				}
+			},
+		},
+	}
+}
+
+// Load fetches (value, true) from cache associated with key or (nil, false) if it is not present.
+func (p *PCache) Load(key typeName) (interface{}, bool) {
+	stripe := p.pool.Get().(*cacheStripe)
+	defer p.pool.Put(stripe)
+	value, ok := stripe.cache[key]
+	return value, ok
+}
+
+// Store stores value for a key in cache.
+func (p *PCache) Store(key typeName, value interface{}) {
+	stripe := p.pool.Get().(*cacheStripe)
+	defer p.pool.Put(stripe)
+
+	stripe.cache[key] = value
+	if len(stripe.cache) <= p.maxSize {
+		return
+	}
+	for k := range stripe.cache {
+		delete(stripe.cache, k)
+		break
+	}
+}


### PR DESCRIPTION
Use local pcache with full type name as key

No perf degradation
```
name                                          old time/op    new time/op    delta
ImmcheckBytes/[16384]byte;muts(0%)-8            4.21µs ±33%    4.03µs ±29%   ~     (p=1.000 n=5+5)
ImmcheckBytes/[16384]byte;muts(1%)-8            3.36µs ±27%    2.92µs ±19%   ~     (p=0.222 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(0%)-8       83.8µs ± 1%    84.0µs ± 1%   ~     (p=0.548 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(1%)-8       84.0µs ± 1%    84.1µs ± 1%   ~     (p=0.548 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8    5.92ms ± 1%    5.90ms ± 2%   ~     (p=0.841 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8    5.90ms ± 1%    5.92ms ± 1%   ~     (p=0.421 n=5+5)

name                                          old muts       new muts       delta
ImmcheckBytes/[16384]byte;muts(0%)-8              0.00           0.00        ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8             4.75k ± 3%     4.77k ± 2%   ~     (p=0.841 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         0.00           0.00        ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(1%)-8          140 ±12%       151 ±20%   ~     (p=0.452 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8      0.00           0.00        ~     (all equal)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8     1.60 ±100%      2.00 ± 0%   ~     (p=0.794 n=5+4)

name                                          old alloc/op   new alloc/op   delta
ImmcheckBytes/[16384]byte;muts(0%)-8             0.00B          0.00B        ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8             0.00B          0.00B        ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         563B ± 1%      563B ± 3%   ~     (p=0.317 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(1%)-8         564B ± 2%      566B ± 1%   ~     (p=0.413 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8    5.91kB ± 1%    5.90kB ± 2%   ~     (p=0.841 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8    6.00kB ± 2%    5.93kB ± 2%   ~     (p=0.421 n=5+5)

name                                          old allocs/op  new allocs/op  delta
ImmcheckBytes/[16384]byte;muts(0%)-8              0.00           0.00        ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8              0.00           0.00        ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         3.00 ± 0%      3.00 ± 0%   ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(1%)-8         3.00 ± 0%      3.00 ± 0%   ~     (all equal)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8      20.0 ± 0%      20.0 ± 0%   ~     (all equal)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8      21.0 ± 0%      20.4 ± 3%   ~     (p=0.095 n=4+5)
```