### PR TITLE
Use reflect type as pcache key

### DIFF
--- a/immcheck_test.go
+++ b/immcheck_test.go
@@ -809,6 +809,12 @@ func expectPanic(t *testing.T, f func(), expectedError error) string {
 		defer func() {
 			actualPanic = recover()
 			if expectedError != nil {
+				if actualPanic == nil {
+					t.Fatalf(
+						"expected error didn't happen. expected %T(%v)",
+						expectedError, expectedError,
+					)
+				}
 				if !errors.Is(actualPanic.(error), expectedError) {
 					t.Fatalf(
 						"unexpected error type. expected %T(%v); actual: %T(%v)",


### PR DESCRIPTION
Use reflect type as pcache key


No perf degradation

```
name                                          old time/op    new time/op    delta
ImmcheckBytes/[16384]byte;muts(0%)-8            4.03µs ±29%    3.32µs ±59%    ~     (p=0.222 n=5+5)
ImmcheckBytes/[16384]byte;muts(1%)-8            2.92µs ±19%    2.57µs ± 7%    ~     (p=0.056 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(0%)-8       84.0µs ± 1%    83.6µs ± 1%    ~     (p=0.151 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(1%)-8       84.1µs ± 1%    83.3µs ± 0%  -0.94%  (p=0.032 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8    5.90ms ± 2%    5.89ms ± 1%    ~     (p=1.000 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8    5.92ms ± 1%    5.90ms ± 1%    ~     (p=0.421 n=5+5)

name                                          old muts       new muts       delta
ImmcheckBytes/[16384]byte;muts(0%)-8              0.00           0.00         ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8             4.77k ± 2%     4.73k ± 3%    ~     (p=1.000 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         0.00           0.00         ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(1%)-8          151 ±20%       143 ±15%    ~     (p=0.690 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8      0.00           0.00         ~     (all equal)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8      2.00 ± 0%     2.00 ±100%    ~     (p=1.000 n=4+5)

name                                          old alloc/op   new alloc/op   delta
ImmcheckBytes/[16384]byte;muts(0%)-8             0.00B          0.00B         ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8             0.00B          0.00B         ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         563B ± 3%      561B ± 2%    ~     (p=0.746 n=5+5)
ImmcheckTransactions/[8]txs(8);muts(1%)-8         566B ± 1%      563B ± 1%    ~     (p=0.349 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8    5.90kB ± 2%    5.88kB ± 2%    ~     (p=0.690 n=5+5)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8    5.93kB ± 2%    5.91kB ± 1%    ~     (p=0.548 n=5+5)

name                                          old allocs/op  new allocs/op  delta
ImmcheckBytes/[16384]byte;muts(0%)-8              0.00           0.00         ~     (all equal)
ImmcheckBytes/[16384]byte;muts(1%)-8              0.00           0.00         ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(0%)-8         3.00 ± 0%      3.00 ± 0%    ~     (all equal)
ImmcheckTransactions/[8]txs(8);muts(1%)-8         3.00 ± 0%      3.00 ± 0%    ~     (all equal)
ImmcheckTransactions/[8]txs(1024);muts(0%)-8      20.0 ± 0%      20.0 ± 0%    ~     (all equal)
ImmcheckTransactions/[8]txs(1024);muts(1%)-8      20.4 ± 3%      20.0 ± 0%    ~     (p=0.333 n=5+4)
```